### PR TITLE
Spell/ Spell book api refactor, spell/spell book removal feature and localStorage caching

### DIFF
--- a/slinger/src/App.js
+++ b/slinger/src/App.js
@@ -123,19 +123,16 @@ class SpellApp extends React.Component {
 
   // Remove a spell book
   removeSpellBook(book) {
-    if (book in this.state.spellBookNames) {
-      this.state.spellBooks.filter((item) => {
-        if (item["name"] !== book) {
-          console.log(item["name"], book);
-          return true;
-        }
-        return false;
-      });
-      this.setState({
-        spellBooks: this.state.spellBooks.filter((item) => item["name"] !== book),
-        spellBookNames: this.state.spellBookNames.filter((item) => item !== book),
-      });
-    }
+    console.log("removing: ", book, this.state.spellBooks);
+    const { [book]: value, ...updatedSpellBooks } = this.state.spellBooks;
+    console.log("result: ", updatedSpellBooks);
+
+    this.setState({
+      spellBooks: updatedSpellBooks,
+      spellBookNames: Object.keys(updatedSpellBooks),
+    });
+    // Update local storage
+    
   }
   /* 
    insert a spell into a spell book
@@ -162,7 +159,7 @@ class SpellApp extends React.Component {
         spellBookNames: this.state.spellBookNames.concat([book]),
       }));
     }
-    if (this.state.spellBooks[book].length !== 0){
+    if (this.state.spellBooks[book].length !== 0) {
       console.log(this.state.spellBooks[book]);
       this.saveToLocalStorage(book);
     }
@@ -197,12 +194,13 @@ class SpellApp extends React.Component {
       let bookName = localStorage.key(i);
       let book = decodeSpellBook(localStorage.getItem(bookName));
       console.log(`${bookName}: ${localStorage.getItem(bookName)}`);
+      console.log(`contains: ${book}`);
       spellBooks[bookName] = book;
     }
     this.setState({
       spellBooks: spellBooks,
       spellBookNames: Object.keys(spellBooks),
-    })
+    });
   }
 
   render() {
@@ -229,10 +227,11 @@ class SpellApp extends React.Component {
           <SpellForm updateSpell={this.updateSpellList.bind(this)} />
           <TemporaryDrawer spellBooks={this.state.spellBookNames} />
           <FormDialog addSpellBook={this.createSpellBook.bind(this)} />
-          <MenuListComposition 
+          <MenuListComposition
             add_icon={false}
             spellBookNames={this.state.spellBookNames}
-            addToSpellBook={(spellBook) => {this.removeSpellBook.bind(this)}}/>
+            addToSpellBook={this.removeSpellBook.bind(this)}
+          />
         </div>
 
         <div className="App-spells">

--- a/slinger/src/components/menu.js
+++ b/slinger/src/components/menu.js
@@ -34,7 +34,7 @@ export default function MenuListComposition(props) {
       return;
     }
 
-    console.log(props);
+    // console.log(props);
 
     setOpen(false);
   };
@@ -43,7 +43,7 @@ export default function MenuListComposition(props) {
     if (anchorRef.current && anchorRef.current.contains(event.target)) {
       return;
     }
-    //console.log("adding to: ", spellBook);
+    // console.log("adding to: ", spellBook);
     props.addToSpellBook(spellBook);
     setOpen(false);
   };

--- a/slinger/src/components/spell_card.js
+++ b/slinger/src/components/spell_card.js
@@ -11,8 +11,8 @@ import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
 
 import IconButton from "@material-ui/core/IconButton";
-//import AddIcon from "@material-ui/icons/Add";
-//import RemoveIcon from "@material-ui/icons/Remove";
+// import AddIcon from "@material-ui/icons/Add";
+import RemoveIcon from "@material-ui/icons/Remove";
 import FlipIcon from "@material-ui/icons/Flip";
 
 import { withStyles } from "@material-ui/core";
@@ -135,7 +135,6 @@ class SpellCard extends React.PureComponent {
         </CardContent>
 
         <CardActions>
-
           <IconButton
             onClick={() => {
               this.setState({ flip_back: !this.state.flip_back });
@@ -143,13 +142,34 @@ class SpellCard extends React.PureComponent {
           >
             <FlipIcon />
           </IconButton>
-          <MenuListComposition
-            add_icon={true}
-            spellBookNames={this.props.spellBookNames}
-            addToSpellBook={(spellBook) => {
-              this.props.updateSpellBook(this.props.spell, spellBook);
-            }}
-          />
+          {this.props.to_add ? (
+            <MenuListComposition
+              add_icon={this.props.to_add}
+              spellBookNames={this.props.spellBookNames}
+              addToSpellBook={(spellBook) => {
+                this.props.updateSpellBook(this.props.spell, spellBook);
+              }}
+            />
+          ) : (
+            /* 
+            TODO: add option to add with a button instead
+                  for when there is only one spell book
+                  or
+                  create the menu with right click that picks a spell book (cached)
+                  while left click adds to the chosen book
+            */
+
+            <IconButton
+              onClick={() => {
+                this.props.updateSpellBook(
+                  this.props.spell,
+                  this.props.spellBook
+                );
+              }}
+            >
+              <RemoveIcon />
+            </IconButton>
+          )}
         </CardActions>
       </Card>
     );

--- a/slinger/src/components/spell_list.js
+++ b/slinger/src/components/spell_list.js
@@ -52,9 +52,11 @@ class SpellList extends React.PureComponent {
                 xl={1}
               >
                 <SpellCard
+                  to_add={this.props.to_add}
                   spell={spell}
                   updateSpellBook={this.props.updateSpellBook}
                   spellBookNames={this.props.spellBookNames}
+                  spellBook={this.props.spellBook}
                 />
               </Grid>
             ) : null;


### PR DESCRIPTION
When in a spell book view the add spell button becomes a remove spell button and the + becomes a -.

The spell updating API changes make for a cleaner interface:
- There is only one way to create a spell book
- add/remove Spell and create/remove SpellBook API update

New state changing approach:
- update state by making a copy of the current state
- make changes to the copy
- set the state to updated copy

This removes the bug where the localStorage lags behind the state by one change.